### PR TITLE
Invoke-GitHubRestAPI:

### DIFF
--- a/Invoke-GitHubRESTApi.ps1
+++ b/Invoke-GitHubRESTApi.ps1
@@ -441,7 +441,12 @@ $($MyInvocation.MyCommand.Name) @parameter
                     @{}
                 }
 
-            $streamIn = [IO.StreamReader]::new($rs, $webResponse.Contentencoding)
+            $streamIn = 
+                if ($webResponse.ContentEncoding) {
+                    [IO.StreamReader]::new($rs, $webResponse.ContentEncoding)
+                } else {
+                    [IO.StreamReader]::new($rs)
+                }
             $strResponse = $streamIn.ReadToEnd()
             if ($webResponse.ContentType -like '*json*') {
                 try {


### PR DESCRIPTION
Only using .ContentEncoding if present in WebResponse.