### PR TITLE
Set-ADOTeam:  Fixing teamfieldvalues parameter sets

### DIFF
--- a/PSDevOps.tests.ps1
+++ b/PSDevOps.tests.ps1
@@ -289,6 +289,18 @@ describe 'Calling REST APIs' {
             $whatIf.uri    | Should -BeLike '*/MyTeam*'
             $whatIf.Method | Should -Be DELETE
         }
+
+        it 'Can set team -DefaultAreaPath and -AreaPath' {
+            $whatIf = 
+                Get-ADOTeam -Organization StartAutomating -Project PSDevOps -TeamID 'PSDevOps Team' -PersonalAccessToken $testPat |
+                    Set-ADOTeam -DefaultAreaPath "MyAreaPath" -WhatIf -AreaPath "An\AreaPath", "Another\AreaPath"
+
+            $whatIf.Method | Should -Be PATCH
+            $whatIf.Uri | Should -BeLike '*teamFieldvalue*'
+            $whatIf.Body.defaultValue | Should -Be MyAreaPath
+
+            
+        } 
     }
 
     context Repositories {

--- a/Set-ADOTeam.ps1
+++ b/Set-ADOTeam.ps1
@@ -27,11 +27,13 @@
 
     # The project.
     [Parameter(Mandatory,ParameterSetName='/{Organization}/{Project}/{Team}/_apis/work/teamsettings',ValueFromPipelineByPropertyName)]
+    [Parameter(Mandatory,ParameterSetName='/{Organization}/{Project}/{Team}/_apis/work/teamsettings/teamfieldvalues',ValueFromPipelineByPropertyName)]
     [string]
     $Project,
 
     # The team.
     [Parameter(Mandatory,ParameterSetName='/{Organization}/{Project}/{Team}/_apis/work/teamsettings',ValueFromPipelineByPropertyName)]
+    [Parameter(Mandatory,ParameterSetName='/{Organization}/{Project}/{Team}/_apis/work/teamsettings/teamfieldvalues',ValueFromPipelineByPropertyName)]
     [string]
     $Team,
 


### PR DESCRIPTION
 (adding -Project and -Team).  Fixes #103