### PR TITLE
Destroy work items switch (permanent delete)

### DIFF
--- a/Functions/AzureDevOps/Remove-ADOWorkItem.ps1
+++ b/Functions/AzureDevOps/Remove-ADOWorkItem.ps1
@@ -8,7 +8,7 @@
     .Example
         Remove-ADOWorkItem -Organization StartAutomating -Project PSDevOps -ID 10
     .Example
-        Remove-ADOWorkItem -Organization StartAutomating -Project PSDevOps -Query "Select [System.ID] from WorkItems Where [System.Title] = 'Test-WorkItem'" -PersonalAccessToken $pat -Confirm:$false
+        Remove-ADOWorkItem -Organization StartAutomating -Project PSDevOps -Query "Select [System.ID] from WorkItems Where [System.Title] = 'Test-WorkItem'" -PersonalAccessToken $pat -Confirm:$false -Destroy
     .Link
         Invoke-ADORestAPI
     .Link
@@ -54,7 +54,11 @@
     # If targeting TFS, this will need to change to match your server version.
     # See: https://docs.microsoft.com/en-us/azure/devops/integrate/concepts/rest-api-versioning?view=azure-devops
     [string]
-    $ApiVersion = "5.1")
+    $ApiVersion = "5.1",
+    
+    # If set, the work item is deleted permanently. Please note: the destroy action is PERMANENT and cannot be undone.
+    [switch]
+    $Destroy)
 
     dynamicParam { . $GetInvokeParameters -DynamicParameter }
     begin {
@@ -80,6 +84,10 @@
             $uri +=
                 if ($ApiVersion) {
                     "api-version=$ApiVersion"
+                }
+            $uri +=
+                if ($Destroy) {
+                    "&destroy=true"
                 }
 
             $invokeParams.Uri = $uri

--- a/docs/Remove-ADOWorkItem.md
+++ b/docs/Remove-ADOWorkItem.md
@@ -27,7 +27,7 @@ Remove-ADOWorkItem -Organization StartAutomating -Project PSDevOps -ID 10
 
 #### EXAMPLE 2
 ```PowerShell
-Remove-ADOWorkItem -Organization StartAutomating -Project PSDevOps -Query "Select [System.ID] from WorkItems Where [System.Title] = 'Test-WorkItem'" -PersonalAccessToken $pat -Confirm:$false
+Remove-ADOWorkItem -Organization StartAutomating -Project PSDevOps -Query "Select [System.ID] from WorkItems Where [System.Title] = 'Test-WorkItem'" -PersonalAccessToken $pat -Confirm:$false -Destroy
 ```
 
 ---
@@ -154,6 +154,23 @@ See: https://docs.microsoft.com/en-us/azure/devops/integrate/concepts/rest-api-v
 
 
 ---
+#### **Destroy**
+
+If set, the work item is deleted permanently. Please note: the destroy action is PERMANENT and cannot be undone.
+
+
+
+> **Type**: ```[SwitchParameter]```
+
+> **Required**: false
+
+> **Position**: named
+
+> **PipelineInput**:false
+
+
+
+---
 #### **WhatIf**
 -WhatIf is an automatic variable that is created when a command has ```[CmdletBinding(SupportsShouldProcess)]```.
 -WhatIf is used to see what would happen, or return operations without executing them
@@ -179,12 +196,12 @@ If the command sets a ```[ConfirmImpact("Medium")]``` which is lower than ```$co
 ---
 ### Syntax
 ```PowerShell
-Remove-ADOWorkItem -Organization <String> -Project <String> -ID <String> [-Server <Uri>] [-ApiVersion <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-ADOWorkItem -Organization <String> -Project <String> -ID <String> [-Server <Uri>] [-ApiVersion <String>] [-Destroy] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 ```PowerShell
-Remove-ADOWorkItem -Organization <String> -Project <String> -Query <String> [-Server <Uri>] [-ApiVersion <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-ADOWorkItem -Organization <String> -Project <String> -Query <String> [-Server <Uri>] [-ApiVersion <String>] [-Destroy] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 ```PowerShell
-Remove-ADOWorkItem -Organization <String> -Project <String> -QueryID <String> [-Server <Uri>] [-ApiVersion <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-ADOWorkItem -Organization <String> -Project <String> -QueryID <String> [-Server <Uri>] [-ApiVersion <String>] [-Destroy] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 ---


### PR DESCRIPTION
Remove-ADOWorkItem.ps1 - Added the functionality to permanently delete work items via "-Destroy" switch parameter.
Updated the docs to reflect this change.

Background: For data protection and privacy reasons we regularly have to delete work items permanently from our Azure DevOps project. That's why implemented the destroy switch.